### PR TITLE
Zaparoo UI features

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -5742,6 +5742,10 @@ int input_test(int getchar)
 						else if (!strcmp(cmd + 7, "unmute")) set_volume(0x80);
 						else if (cmd[7] >= '0' && cmd[7] <= '7') set_volume(0x40 - 0x30 + cmd[7]);
 					}
+					else if (!strncmp(cmd, "show_picker", 11))
+					{
+						menu_show_picker();
+					}
 				}
 			}
 

--- a/input.cpp
+++ b/input.cpp
@@ -5746,6 +5746,10 @@ int input_test(int getchar)
 					{
 						menu_show_picker();
 					}
+					else if (!strncmp(cmd, "show_notice ", 12))
+					{
+						menu_show_notice(cmd + 12);
+					}
 				}
 			}
 

--- a/menu.cpp
+++ b/menu.cpp
@@ -201,7 +201,13 @@ enum MENU
 	// MT32-pi
 	MENU_MT32PI_MAIN1,
 	MENU_MT32PI_MAIN2,
+
+	// External widgets
+	MENU_PICKER_SELECTED,
 };
+
+#define MENU_PICKER_ITEMS_DIR "/tmp/PICKERITEMS"
+#define MENU_PICKER_SELECTED_FILE "/tmp/PICKERSELECTED"
 
 static uint32_t menustate = MENU_NONE1;
 static uint32_t parentstate;
@@ -6938,6 +6944,12 @@ void HandleUI(void)
 		SelectFile("", 0, SCANO_CORES, MENU_CORE_FILE_SELECTED1, cp_MenuCancel);
 		break;
 
+	case MENU_PICKER_SELECTED:
+		memcpy(Selected_tmp, selPath, sizeof(Selected_tmp));
+		MakeFile(MENU_PICKER_SELECTED_FILE, Selected_tmp);
+		OsdClear();
+		break;
+
 		/******************************************************************/
 		/* we should never come here                                      */
 		/******************************************************************/
@@ -7381,4 +7393,20 @@ void ProgressMessage(const char* title, const char* text, int current, int max)
 
 		if (loader_bg) InfoMessage(progress_buf, 2000, title);
 	}
+}
+
+// Displays a list picker on the OSD (and opens the OSD if necessary) based on
+// .txt files listed from the picker items directory at the time of execution.
+//
+// Once the user selects an item, the file path of the item is written to
+// picker selected file which can be monitored with inotify. The external
+// process is expected to create, manage and clean up the items directory.
+void menu_show_picker()
+{
+	FileCreatePath(MENU_PICKER_ITEMS_DIR);
+	// dunno how to temporarily set the root so we're using a relative path
+	snprintf(Selected_tmp, sizeof(Selected_tmp), "../..%s", MENU_PICKER_ITEMS_DIR);
+	// TODO: explicitly set the OSD size?
+	OsdEnable(DISABLE_KEYBOARD);
+	SelectFile(Selected_tmp, "TXT", SCANO_TXT, MENU_PICKER_SELECTED, MENU_NONE1);
 }

--- a/menu.cpp
+++ b/menu.cpp
@@ -204,6 +204,7 @@ enum MENU
 
 	// External widgets
 	MENU_PICKER_SELECTED,
+	MENU_NOTICE,
 };
 
 #define MENU_PICKER_ITEMS_DIR "/tmp/PICKERITEMS"
@@ -7409,4 +7410,45 @@ void menu_show_picker()
 	// TODO: explicitly set the OSD size?
 	OsdEnable(DISABLE_KEYBOARD);
 	SelectFile(Selected_tmp, "TXT", SCANO_TXT, MENU_PICKER_SELECTED, MENU_NONE1);
+}
+
+// Displays a notice on the OSD (and opens the OSD if necessary) with the given
+// message. The notice will be displayed until the user interacts with the OSD
+// or main restarts/a core is launched.
+//
+// The notice is automatically wrapped to fit the OSD display or until a newline
+// character is encountered in the message. Any message length longer than the
+// current OSD display height will be truncated.
+void menu_show_notice(const char *msg)
+{
+	char line[30] = {0};
+	int linep = 0;
+	OsdSetTitle("Notice");
+	int n = 0;
+	int max_lines = OsdGetSize();
+	for (const char *c = msg; *c != '\0'; c++)
+	{
+		if (*c == '\n' || linep >= 29)
+		{
+			OsdWrite(n++, line);
+			if (n >= max_lines)
+				break;
+			linep = 0;
+			memset(line, '\0', sizeof(line));
+		}
+		if (*c != '\n')
+		{
+			line[linep++] = *c;
+		}
+	}
+	if (linep > 0 && n < max_lines)
+	{
+		OsdWrite(n++, line);
+	}
+	for (; n < max_lines; n++)
+	{
+		OsdWrite(n, "");
+	}
+	OsdUpdate();
+	OsdEnable(OSD_MSG);
 }

--- a/menu.h
+++ b/menu.h
@@ -28,5 +28,6 @@ int menu_present();
 extern int loader_bg;
 
 void menu_show_picker();
+void menu_show_notice(const char *msg);
 
 #endif

--- a/menu.h
+++ b/menu.h
@@ -27,4 +27,6 @@ void StoreIdx_S(int idx, const char *path);
 int menu_present();
 extern int loader_bg;
 
+void menu_show_picker();
+
 #endif

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1105,7 +1105,7 @@ void SetUARTMode(int mode)
 	MakeFile("/tmp/CORENAME", user_io_get_core_name());
     MakeFile("/tmp/RBFNAME", user_io_get_core_name(1));
 
-	MakeFile("/tmp/MAINFEATURES", "PICKER,NOTICE");
+	MakeFile("/tmp/MAINFEATURES", "PICKER,NOTICE,LOADSCREEN,STANDBYSCREEN,MGLEXTENDED");
 
 	char data[20];
 	sprintf(data, "%d", baud);

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1105,7 +1105,7 @@ void SetUARTMode(int mode)
 	MakeFile("/tmp/CORENAME", user_io_get_core_name());
     MakeFile("/tmp/RBFNAME", user_io_get_core_name(1));
 
-	MakeFile("/tmp/MAINFEATURES", "PICKER");
+	MakeFile("/tmp/MAINFEATURES", "PICKER,NOTICE");
 
 	char data[20];
 	sprintf(data, "%d", baud);

--- a/user_io.cpp
+++ b/user_io.cpp
@@ -1105,6 +1105,8 @@ void SetUARTMode(int mode)
 	MakeFile("/tmp/CORENAME", user_io_get_core_name());
     MakeFile("/tmp/RBFNAME", user_io_get_core_name(1));
 
+	MakeFile("/tmp/MAINFEATURES", "PICKER");
+
 	char data[20];
 	sprintf(data, "%d", baud);
 	MakeFile("/tmp/UART_SPEED", data);


### PR DESCRIPTION
Here is the PR we discussed, which adds the following features:

- An OSD list picker widget which can be set up and triggered by external processes.
- An OSD notice widget which can be triggered by external processes.
- A new file in /tmp which advertises to external apps that these features are available.

I have also added LOADSCREEN, STANDBYSCREEN and MGLEXTENDED to this new file, so apps can tell that your own fork's features are available to use. Feel free to name them something more appropriate or add things if I missed something.